### PR TITLE
Add pkgdown author profiles

### DIFF
--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -8,7 +8,6 @@ authors:
     href: "https://github.com/sima-njf"
   "George Vega Yon":
     href: "https://ggvy.cl"
-    html: "<img src='https://ggvy.cl/img/george-g-vega-yon-university-of-utah.webp' width=72 alt=''>"
   "Kyosuke Tanaka":
     href: "https://orcid.org/0000-0002-1850-6814"
 

--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -2,7 +2,16 @@ url: https://gvegayon.github.io/imaginary-structures
 
 template:
   bootstrap: 5
-  
+
+authors:
+  "Sima Najafzadehkhoei":
+    href: "https://github.com/sima-njf"
+  "George Vega Yon":
+    href: "https://ggvy.cl"
+    html: "<img src='https://ggvy.cl/img/george-g-vega-yon-university-of-utah.webp' width=72 alt=''>"
+  "Kyosuke Tanaka":
+    href: "https://orcid.org/0000-0002-1850-6814"
+
 home:
   title: "Imaginary CSS Structures"
   description: >


### PR DESCRIPTION
## Summary

- link George Vega Yon to https://ggvy.cl while preserving his displayed name
- add profile links for every package author listed in DESCRIPTION
- add a source pkgdown configuration where the published site did not already have one

## Validation

- loaded the package metadata with pkgdown
- verified exact author-name matching against DESCRIPTION
- verified every configured author mapping contains only an href attribute

Related to gvegayon/website#32.